### PR TITLE
Add setup script

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+# Setup script for the Scrabble Erlang application on Ubuntu 24.04
+set -e
+
+# Update package index
+sudo apt-get update
+
+# Install Erlang/OTP and rebar3 build tool
+sudo apt-get install -y erlang rebar3
+
+# Compile the project
+rebar3 compile
+
+# Completion message
+echo "Setup complete. You can run the game with 'rebar3 shell' and then 'play:game().'"


### PR DESCRIPTION
## Summary
- add a `setup.sh` script to install Erlang/OTP and rebar3 on Ubuntu 24.04
- compile the app automatically as part of the setup

## Testing
- `./setup.sh`

------
https://chatgpt.com/codex/tasks/task_e_684f77e956048323bb05977ebeead576